### PR TITLE
Port the ChangePlayerAttributes trigger to Lönn

### DIFF
--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1,0 +1,10 @@
+triggers.Styline/ChangePlayerAttributes.placements.name.rectangle=Change Player Attributes
+
+triggers.Styline/ChangePlayerAttributes.attributes.description.applyImmediately=Whether the attributes should be applied immediately when the trigger loads, instead of on enter.
+triggers.Styline/ChangePlayerAttributes.attributes.description.applyOnce=Whether the attributes should only be applied once.\nChecks for a flag named "[room]:[entityid]Applied", where [room] is the room name, and [entityid] is the entity ID in Lönn.
+triggers.Styline/ChangePlayerAttributes.attributes.description.hairColor=The path to the YAML file containing the hair color.\nRelative to "Content/", without extension.
+triggers.Styline/ChangePlayerAttributes.attributes.description.hairStyle=The path to the YAML file containing the hair style.\nRelative to "Content/", without extension.
+triggers.Styline/ChangePlayerAttributes.attributes.description.hairAccessory=The path to the YAML file containing the hair accessory.\nRelative to "Content/", without extension.
+triggers.Styline/ChangePlayerAttributes.attributes.description.hairAccessoryColor=The path to the YAML file containing the hair accessory color.\nRelative to "Content/", without extension.
+triggers.Styline/ChangePlayerAttributes.attributes.description.shirtColor=The path to the YAML file containing the shirt colors.\nRelative to "Content/", without extension.
+triggers.Styline/ChangePlayerAttributes.attributes.description.blushColor=The path to the YAML file containing the blush color.\nRelative to "Content/", without extension.

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -1,6 +1,6 @@
 triggers.Styline/ChangePlayerAttributes.placements.name.rectangle=Change Player Attributes
 
-triggers.Styline/ChangePlayerAttributes.attributes.description.applyImmediately=Whether the attributes should be applied immediately when the trigger loads, instead of on enter.
+triggers.Styline/ChangePlayerAttributes.attributes.description.applyImmediately=Whether the trigger should be activated immediately when it loads, on top of activating on enter.
 triggers.Styline/ChangePlayerAttributes.attributes.description.applyOnce=Whether the attributes should only be applied once.\nChecks for a flag named "[room]:[entityid]Applied", where [room] is the room name, and [entityid] is the entity ID in Lönn.
 triggers.Styline/ChangePlayerAttributes.attributes.description.hairColor=The path to the YAML file containing the hair color.\nRelative to "Content/", without extension.
 triggers.Styline/ChangePlayerAttributes.attributes.description.hairStyle=The path to the YAML file containing the hair style.\nRelative to "Content/", without extension.

--- a/Loenn/triggers/ChangePlayerAttributes.lua
+++ b/Loenn/triggers/ChangePlayerAttributes.lua
@@ -1,0 +1,18 @@
+local trigger = {}
+
+trigger.name = "Styline/ChangePlayerAttributes"
+trigger.placements = {
+  name = "rectangle",
+  data = {
+    applyImmediately = false,
+    applyOnce = false,
+    hairColor = "",
+    hairStyle = "",
+    hairAccessory = "",
+    hairAccessoryColor = "",
+    shirtColor = "",
+    blushColor = ""
+  }
+}
+
+return trigger


### PR DESCRIPTION
Self-explanatory.
Ports the Ahorn-only `ChangePlayerAttributes` trigger to Lönn.